### PR TITLE
Add MIT license and improve server startup docs

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2024 ServerApp contributors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,38 @@
 # ServerApp
-HTML console buttons access
+
+A minimal skeleton for a NeoForge Minecraft server with a web-based GUI.
+
+## Prerequisites
+
+- **Enable RCON** in your `server.properties` so external tools can communicate with the server. Set `enable-rcon=true`, specify `rcon.port` and `rcon.password`.
+- **Node.js** is required for the planned GUI service. Install it from [nodejs.org](https://nodejs.org/).
+- **Environment variables** (optional) used by the GUI:
+  - `RCON_HOST` – hostname of the running server (default `localhost`).
+  - `RCON_PORT` – RCON port number.
+  - `RCON_PASSWORD` – password configured in `server.properties`.
+
+## Starting the NeoForge server
+
+Launch the server on Windows using `run.bat`:
+
+```bat
+run.bat
+```
+
+The script passes necessary JVM arguments and starts NeoForge. Edit `user_jvm_args.txt` for custom options.
+
+## Planned GUI interaction
+
+The `gui/` directory holds placeholder files for a future web interface. When implemented, `gui/server.js` will read the environment variables above, connect via RCON, and expose a web console.
+
+To start the GUI (once developed):
+
+```bash
+node gui/server.js
+```
+
+It will forward console commands and show output from the running server.
+
+## License
+
+This project is available under the MIT License. See [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary
- document how to run the NeoForge server and planned GUI
- mention prerequisites including RCON and Node.js
- provide environment variables used by the GUI
- add MIT license file

## Testing
- `node --version`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68892b0e0b6c832f81a374ba6ff0f27f